### PR TITLE
setup.py --help and egg_info should not trigger imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,13 @@ import sys
 
 from setuptools import setup, find_packages
 
-from uzmq import __version__
+with open(
+        os.path.join(
+            os.path.dirname(__file__), "uzmq", "__version__.py"
+        )
+) as version_file:
+    exec(version_file.read())
+
 
 py_version = sys.version_info[:2]
 

--- a/uzmq/__init__.py
+++ b/uzmq/__init__.py
@@ -9,9 +9,7 @@ Classes
 - ``ZMQPoll`` : :doc:`poll` class
 
 """
-
-version_info = (0, 3, 1)
-__version__ = ".".join([str(v) for v in version_info])
+from __version__ import __version__
 
 from uzmq.poll import ZMQPoll
 from uzmq.sock import ZMQ

--- a/uzmq/__version__.py
+++ b/uzmq/__version__.py
@@ -1,0 +1,2 @@
+version_info = (0, 3, 1)
+__version__ = ".".join([str(v) for v in version_info])


### PR DESCRIPTION
Should fix #2 

This problem exists in many packages. 
Simple setup command shouldn't trigger any imports, as lack of dependancies will 
break egg_info used by pip -r requirements.txt
